### PR TITLE
Update analyzer unittest, sh, etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ db-data
 node_modules
 dist
 bin
+
+# Editor temporary files
+*~

--- a/codeanalysis/js/callgraph-analysis/Dockerfile
+++ b/codeanalysis/js/callgraph-analysis/Dockerfile
@@ -8,6 +8,7 @@ COPY --chown=analysis src /analyzer
 COPY --chown=analysis analyze.sh /analyzer/
 COPY --chown=analysis package.json /analyzer/
 COPY --chown=analysis tsconfig.json /analyzer/
+COPY --chown=analysis unittest.sh /analyzer/
 
 WORKDIR /analyzer
 RUN yarn install

--- a/codeanalysis/js/callgraph-analysis/analyze.sh
+++ b/codeanalysis/js/callgraph-analysis/analyze.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-TARGET="/tmp/analysis/code"
+set -e
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="/analysis/inputs/com.returntocorp.cloner"
 
 # File size limit of 250 KB
-node --max_old_space_size=2048 --stack-size=8000 /analyzer/dist/index.js ${TARGET} 250000 false r2c
+node --max_old_space_size=2048 --stack-size=8000 /analyzer/dist/index.js ${TARGET} 250000 false r2c >/analysis/output/output.json
 
-# Needed to fix unmount problems with docker on some operating systems
-rm -Rf /tmp/analysis/code

--- a/codeanalysis/js/callgraph-analysis/unittest.sh
+++ b/codeanalysis/js/callgraph-analysis/unittest.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "hi"


### PR DESCRIPTION
A few minor changes / things I forgot to include earlier:

- Ignore editor files (just for my convenience)
- We require a unittest.sh file, even if it does nothing
- Inputs now correspond to the names in the `analyzer.json` file, so for the input code it would show up under `/analysis/inputs/com.returntocorp.cloner` rather than `/tmp/analysis/code`
- (JSON output) goes to `/analysis/output/output.json`